### PR TITLE
画面収録機能は解決しました。全てのやり方を公式ドキュメントとサンプルプロジェクトから吸収した。

### DIFF
--- a/web/README.txt
+++ b/web/README.txt
@@ -8,4 +8,4 @@ backendでは
 uvicorn main:app --reload
 
 を実行。
-backendでは最初にpip install -r requirement.txtを実行してください。
+backendでは最初にpip install -r requirement.txtを実行してください。　


### PR DESCRIPTION
https://developer.apple.com/documentation/screencapturekit/capturing_screen_content_in_macos
ここに飛んでdownloadでまずサンプルプロジェクトをダウンロードしてみて。
ここに書いてあるコードをいじったら確実にうまくいく（確信）
あとはファイルに保存する操作だけど、一枚一枚のフレームを取得してる部分がサンプルの中にあったからそれとSwiftのAVAssetWriter使えばファイルとしてその画像たちを構成して保存できるらしい。GCSのアップロードする部分は、Resumable Upload(shared)を使うと動画みたいな大きなファイルでも小さなチャンクに分割しておくることが出来て、送信の失敗も少なくなるらしい。